### PR TITLE
Fix the syntax for dataset names

### DIFF
--- a/docs/earth-age.rst
+++ b/docs/earth-age.rst
@@ -18,7 +18,7 @@ Usage
 
 You access a global crustal age grid by specifying the special name
 
-   @earth_age_\ *rr*\ [*u*\ [_\ *reg*\ ]]
+   @earth_age[_\ *rru*\ [_\ *reg*\ ]]
 
 The following codes for *rr*\ *u* and the optional *reg* are supported (dimensions are listed
 for pixel-registered grids; gridline-registered grids increment dimensions by one):

--- a/docs/earth-daynight.rst
+++ b/docs/earth-daynight.rst
@@ -22,11 +22,11 @@ Usage
 
 You access a global daytime image by specifying the special names
 
-   @earth_day_\ [*rr*\ *u*]
+   @earth_day[_\ *rru*]
 
 Similarly for the nighttime view:
 
-   @earth_night_\ [*rr*\ *u*]
+   @earth_night[_\ *rru*]
 
 The following codes for *rr*\ *u* and the optional *reg* are supported (dimensions are listed
 for pixel-registered grids; gridline-registered grids increment dimensions by one):

--- a/docs/earth-faa.rst
+++ b/docs/earth-faa.rst
@@ -21,7 +21,7 @@ Usage
 
 You access a global free-air (faa) grid by specifying the special name
 
-   @earth_faa_\ [*rr*\ *u*\ [_\ *reg*\ ]]
+   @earth_faa[_\ *rru*\ [_\ *reg*\ ]]
 
 The following codes for *rr*\ *u* and the optional *reg* are supported (dimensions are listed
 for pixel-registered grids; gridline-registered grids increment dimensions by one):

--- a/docs/earth-gebco.rst
+++ b/docs/earth-gebco.rst
@@ -16,12 +16,12 @@ Usage
 
 You access the GEBCO global relief grid by specifying the special name
 
-   @earth_gebco_\ [*rr*\ *u*\ [_\ *reg*\ ]]
+   @earth_gebco[_\ *rru*\ [_\ *reg*\ ]]
 
 This grid only contains observed relief and inferred relief via altimetric gravity.
 A second grid that gives sub-ice (si) elevations is also available and can be accessed via
 
-   @earth_gebcosi_\ [*rr*\ *u*\ [_\ *reg*\ ]]
+   @earth_geocosi[_\ *rru*\ [_\ *reg*\ ]]
 
 and is the one displayed above.  The following codes for *rr*\ *u* and the optional *reg* are supported (dimensions are listed
 for pixel-registered grids; gridline-registered grids increment dimensions by one):

--- a/docs/earth-geoid.rst
+++ b/docs/earth-geoid.rst
@@ -13,7 +13,7 @@ Usage
 
 You access a global geoid grid by specifying the special name
 
-   @earth_geoid_\ [*rr*\ *u*\ [_\ *reg*\ ]]
+   @earth_geoid[_\ *rru*\ [_\ *reg*\ ]]
 
 The following codes for *rr*\ *u* and the optional *reg* are supported (dimensions are listed
 for pixel-registered grids; gridline-registered grids increment dimensions by one):

--- a/docs/earth-mag.rst
+++ b/docs/earth-mag.rst
@@ -14,13 +14,13 @@ Usage
 
 You access a global EMAG2 grid by specifying the special name
 
-   @earth_mag_\ [*rr*\ *u*\ [_\ *reg*\ ]]
+   @earth_mag[_\ *rru*\ [_\ *reg*\ ]]
 
 This version is observed at sea level over oceanic regions and have no data over land.
 For a version where all observations are relative to an altitude of 4 km above the geoid
 and includes data over land, use instead
 
-   @earth_mag4km_\ [*rr*\ *u*\ [_\ *reg*\ ]]
+   @earth_mag4km[_\ *rru*\ [_\ *reg*\ ]]
 
 The following codes for *rr*\ *u* and the optional *reg* are supported (dimensions are listed
 for pixel-registered grids; gridline-registered grids increment dimensions by one). The sizes

--- a/docs/earth-masks.rst
+++ b/docs/earth-masks.rst
@@ -22,7 +22,7 @@ Usage
 
 You access a global mask grid by specifying the special name
 
-   @earth_mask_\ [*rr*\ *u*\ [_\ *reg*\ ]]
+    @earth_mask[_\ *rru*\ [_\ *reg*\ ]]
 
 The following codes for *rr*\ *u* and the optional *reg* are supported (dimensions are listed
 for pixel-registered grids; gridline-registered grids increment dimensions by one):

--- a/docs/earth-relief.rst
+++ b/docs/earth-relief.rst
@@ -16,14 +16,14 @@ Usage
 
 You access a global relief grid by specifying the special name
 
-   @earth_relief_\ [*rr*\ *u*\ [_\ *reg*\ ]]
+   @earth_relief[_\ *rru*\ [_\ *reg*\ ]]
 
 This grid only contains observed relief and inferred relief via altimetric gravity.
 A new version that uses the statistical properties of young seafloor fabric and
 directions of spreading is also available and provides more realistic relief in
 areas of young seafloor with small seamounts.  That grid can be accessed via
 
-   @earth_synbath_\ [*rr*\ *u*\ [_\ *reg*\ ]]
+   @earth_synbath[_\ *rru*\ [_\ *reg*\ ]]
 
 The following codes for the optional *rr*\ *u* and *reg* are supported (dimensions are listed
 for pixel-registered grids; gridline-registered grids increment dimensions by one):

--- a/docs/earth-vgg.rst
+++ b/docs/earth-vgg.rst
@@ -20,7 +20,7 @@ Usage
 
 You access a global vertical gravity gradient (vgg) grid by specifying the special name
 
-   @earth_vgg_\ [*rr*\ *u*\ [_\ *reg*\ ]]
+   @earth_vgg[_\ *rru*\ [_\ *reg*\ ]]
 
 The following codes for *rr*\ *u* and the optional *reg* are supported (dimensions are listed
 for pixel-registered grids; gridline-registered grids increment dimensions by one):

--- a/docs/earth-wdmam.rst
+++ b/docs/earth-wdmam.rst
@@ -17,7 +17,7 @@ Usage
 
 You access a global WDMAM grid by specifying the special name
 
-   @earth_wdmam_\ [*rr*\ *u*\ [_\ *reg*\ ]]
+   @earth_wdmam[_\ *rru*\ [_\ *reg*\ ]]
 
 The following codes for *rr*\ *u* and the optional *reg* are supported (dimensions are listed
 for pixel-registered grids; gridline-registered grids increment dimensions by one):


### PR DESCRIPTION
| Old syntax | New syntax
|---|---|
|<img width="183" alt="image" src="https://user-images.githubusercontent.com/3974108/156876156-39cabc06-0b13-4271-b9e2-579c828b1d4d.png">|<img width="177" alt="image" src="https://user-images.githubusercontent.com/3974108/156876207-500ce878-5973-42c9-acaf-e0f69040d72a.png">|

Apparently, the old syntax is wrong, because `@earth_relief_` is not a valid name. This PR fixes all the dataset names to the new syntax.

