### PR TITLE
Update SRTM15+ to v2.4

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -1,6 +1,11 @@
 Changelog
 ---------
 
+2022-03-22
+^^^^^^^^^^
+
+- Update ``earth_relief`` source from SRTM15+V2.3 to SRTM15+V2.4 [`Tozer et al., 2019 <https://doi.org/10.1029/2019EA000658>`_].
+
 2022-01-28
 ^^^^^^^^^^
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,7 +4,7 @@ Changelog
 2022-03-22
 ^^^^^^^^^^
 
-- Update ``earth_relief`` source from SRTM15+V2.3 to SRTM15+V2.4 [`Sandwell et al., 2022 <http://dx.doi.org/10.1002/essoar.10508279.1>`_].
+- Update ``earth_relief`` source from SRTM15+V2.3 to SRTM15+V2.4 [`Tozer et al., 2019 <https://doi.org/10.1029/2019EA000658>`_].
 
 2022-01-28
 ^^^^^^^^^^

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -1,6 +1,12 @@
 Changelog
 ---------
 
+2022-04-01
+^^^^^^^^^^
+
+- Update citation for SRTM15+V2.4 [`Tozer et al., 2019 <https://doi.org/10.1029/2019EA000658>`_].
+- Fix 30s topography grids (`Remote-datasets issue #32 <https://github.com/GenericMappingTools/remote-datasets/issues/32>_`).
+
 2022-03-22
 ^^^^^^^^^^
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,7 +4,7 @@ Changelog
 2022-03-22
 ^^^^^^^^^^
 
-- Update ``earth_relief`` source from SRTM15+V2.3 to SRTM15+V2.4 [`Tozer et al., 2019 <https://doi.org/10.1029/2019EA000658>`_].
+- Update ``earth_relief`` source from SRTM15+V2.3 to SRTM15+V2.4 [`Sandwell et al., 2022 <http://dx.doi.org/10.1002/essoar.10508279.1>`_].
 
 2022-01-28
 ^^^^^^^^^^

--- a/docs/earth-relief.rst
+++ b/docs/earth-relief.rst
@@ -61,7 +61,7 @@ Technical Information
 ~~~~~~~~~~~~~~~~~~~~~
 
 As you see, the 30s and lower resolutions are all derivatives of Scripps' SRTM15+V2.4 grid
-(Sandwell et al., 2022).  We have downsampled it via Cartesian Gaussian filtering to prevent
+(Tozer et al., 2019).  We have downsampled it via Cartesian Gaussian filtering to prevent
 aliasing while preserving the latitude-dependent resolution in the original 15 arc sec grid.
 The full (6 sigma) filter-widths are indicated in parenthesis. The 3 and 1 arc second data
 are the SRTM 1x1 degree tiles from NASA.  **Note**: The 3 and 1 arc second grids only extend

--- a/docs/earth-relief.rst
+++ b/docs/earth-relief.rst
@@ -35,19 +35,19 @@ for pixel-registered grids; gridline-registered grids increment dimensions by on
   ==== ================= === =======  ==================================================
   Code Dimensions        Reg Size     Description
   ==== ================= === =======  ==================================================
-  01d       360 x    180 g,p  114 KB  1 arc degree global relief (SRTM15+V2.3 @ 111 km)
-  30m       720 x    360 g,p  395 KB  30 arc minute global relief (SRTM15+V2.3 @ 55 km)
-  20m      1080 x    540 g,p  832 KB  20 arc minute global relief (SRTM15+V2.3 @ 37 km)
-  15m      1440 x    720 g,p  1.4 MB  15 arc minute global relief (SRTM15+V2.3 @ 28 km)
-  10m      2160 x   1080 g,p  3.0 MB  10 arc minute global relief (SRTM15+V2.3 @ 18 km)
-  06m      3600 x   1800 g,p  8.0 MB  6 arc minute global relief (SRTM15+V2.3 @ 10 km)
-  05m*     4320 x   2160 g,p   11 MB  5 arc minute global relief (SRTM15+V2.3 @ 9 km)
-  04m*     5400 x   2700 g,p   17 MB  4 arc minute global relief (SRTM15+V2.3 @ 7.5 km)
-  03m*     7200 x   3600 g,p   30 MB  3 arc minute global relief (SRTM15+V2.3 @ 5.6 km)
-  02m*    10800 x   5400 g,p   65 MB  2 arc minute global relief (SRTM15+V2.3 @ 3.7 km)
-  01m*    21600 x  10800 g,p  237 MB  1 arc minute global relief (SRTM15+V2.3 @ 1.9 km)
-  30s*    43200 x  21600 g,p  864 MB  30 arc second global relief (SRTM15+V2.3 @ 1.0 km)
-  15s*    86400 x  43200 p    2.9 GB  15 arc second global relief (SRTM15+V2.3)
+  01d       360 x    180 g,p  114 KB  1 arc degree global relief (SRTM15+V2.4 @ 111 km)
+  30m       720 x    360 g,p  395 KB  30 arc minute global relief (SRTM15+V2.4 @ 55 km)
+  20m      1080 x    540 g,p  832 KB  20 arc minute global relief (SRTM15+V2.4 @ 37 km)
+  15m      1440 x    720 g,p  1.4 MB  15 arc minute global relief (SRTM15+V2.4 @ 28 km)
+  10m      2160 x   1080 g,p  3.0 MB  10 arc minute global relief (SRTM15+V2.4 @ 18 km)
+  06m      3600 x   1800 g,p  8.0 MB  6 arc minute global relief (SRTM15+V2.4 @ 10 km)
+  05m*     4320 x   2160 g,p   11 MB  5 arc minute global relief (SRTM15+V2.4 @ 9 km)
+  04m*     5400 x   2700 g,p   17 MB  4 arc minute global relief (SRTM15+V2.4 @ 7.5 km)
+  03m*     7200 x   3600 g,p   30 MB  3 arc minute global relief (SRTM15+V2.4 @ 5.6 km)
+  02m*    10800 x   5400 g,p   65 MB  2 arc minute global relief (SRTM15+V2.4 @ 3.7 km)
+  01m*    21600 x  10800 g,p  237 MB  1 arc minute global relief (SRTM15+V2.4 @ 1.9 km)
+  30s*    43200 x  21600 g,p  864 MB  30 arc second global relief (SRTM15+V2.4 @ 1.0 km)
+  15s*    86400 x  43200 p    2.9 GB  15 arc second global relief (SRTM15+V2.4)
   03s*   432000 x 216000 g    6.8 GB  3 arc second global relief (SRTM3S)
   01s*  1296000 x 432000 g     41 GB  1 arc second global relief (SRTM1S)
   ==== ================= === =======  ==================================================
@@ -60,7 +60,7 @@ do not specify a CPT then this dataset default to the GMT master *geo*.
 Technical Information
 ~~~~~~~~~~~~~~~~~~~~~
 
-As you see, the 30s and lower resolutions are all derivatives of Scripps' SRTM15+V2.3 grid
+As you see, the 30s and lower resolutions are all derivatives of Scripps' SRTM15+V2.4 grid
 (Sandwell et al., 2022).  We have downsampled it via Cartesian Gaussian filtering to prevent
 aliasing while preserving the latitude-dependent resolution in the original 15 arc sec grid.
 The full (6 sigma) filter-widths are indicated in parenthesis. The 3 and 1 arc second data
@@ -70,12 +70,12 @@ to latitudes ±60˚ and are only available over land.  When these grids are acce
 tiles to fill in the missing ocean values. If you just want the original land-only SRTM tiles
 you may use the special names @srtm_relief_03s or @srtm_relief_01s instead. Almost all grids
 are available in both gridline- and pixel-registered formats except the original pixel-registered
-SRTM15+V2.3 (here called @earth_relief_15s) and the gridline-registered SRTM tiles.
+SRTM15+V2.4 (here called @earth_relief_15s) and the gridline-registered SRTM tiles.
 
 Data References
 ~~~~~~~~~~~~~~~
 
-#. SRTM15+V2.3: [https://doi.org/10.1029/2021EA002069].
+#. SRTM15+V2.4: [https://doi.org/10.1029/2019EA000658].
 #. SYNBATH_V1.2: [https://doi.org/10.1029/2021EA002069].
 #. SRTMGL3 tiles: [https://lpdaac.usgs.gov/products/srtmgl3v003].
 #. SRTMGL1 tiles: [https://lpdaac.usgs.gov/products/srtmgl1v003].


### PR DESCRIPTION
The SRTM15+ files have been updated to v2.4 on the server. This PR updates the documentation. It also changes the citation for SRTM15+ to Tozer et al., 2019, because Sandwell et al., 2022 covers the synbath dataset but not the full details of SRTM15+.

Fixes https://github.com/GenericMappingTools/remote-datasets/issues/33