### PR TITLE
Fix highest resolution registrations

### DIFF
--- a/docs/earth-age.rst
+++ b/docs/earth-age.rst
@@ -40,7 +40,7 @@ for pixel-registered grids; gridline-registered grids increment dimensions by on
   04m*     5400 x   2700 g,p   15 MB  4 arc minute global relief (1 min @ 7.5 km)
   03m*     7200 x   3600 g,p   26 MB  3 arc minute global relief (1 min @ 5.6 km)
   02m*    10800 x   5400 g,p   56 MB  2 arc minute global relief (1 min @ 3.7 km)
-  01m*    21600 x  10800 g,p  188 MB  1 arc minute global relief (1 min original)
+  01m*    21600 x  10800 g    188 MB  1 arc minute global relief (1 min original)
   ==== ================= === =======  ==================================================
 
 See :gmt-docs:`GMT remote dataset usage <datasets/remote-data.html#usage>` for when resolution codes are optional or required.

--- a/docs/earth-daynight.rst
+++ b/docs/earth-daynight.rst
@@ -28,8 +28,7 @@ Similarly for the nighttime view:
 
    @earth_night[_\ *rru*]
 
-The following codes for *rr*\ *u* and the optional *reg* are supported (dimensions are listed
-for pixel-registered grids; gridline-registered grids increment dimensions by one):
+The following codes for *rr*\ *u* are supported:
 
 .. _tbl-earth_daynight:
 

--- a/docs/earth-wdmam.rst
+++ b/docs/earth-wdmam.rst
@@ -37,7 +37,7 @@ for pixel-registered grids; gridline-registered grids increment dimensions by on
   06m      3600 x   1800 g,p  5.7 MB  6 arc minute global WDMAM (3 min @ 10 km)
   05m*     4320 x   2160 g,p  9.3 MB  5 arc minute global WDMAM (3 min @ 9 km)
   04m*     5400 x   2700 g,p   14 MB  4 arc minute global WDMAM (3 min @ 7.5 km)
-  03m*     7200 x   3600 g,p   24 MB  3 arc minute global WDMAM (3 min original)
+  03m*     7200 x   3600 g     24 MB  3 arc minute global WDMAM (3 min original)
   ==== ================= === =======  ==========================================
 
 See :gmt-docs:`GMT remote dataset usage <datasets/remote-data.html#usage>` for when resolution codes are optional or required.


### PR DESCRIPTION
Age starts at 1m gridline, wdmam is 3m gridline, while daynight are only pixel registration so language about gridline-reg goes away.