### PR TITLE
Fix URLs following Crossref DOI display guidelines

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -41,9 +41,9 @@ Changelog
 - ``earth_gebcosi``: Add new dataset 'GEBCO Sub-Ice Earth Relief' [`GEBCO Compilation Group, 2021 GEBCO 2021 Grid <https://www.gebco.net/data_and_products/gridded_bathymetry_data/>`_].
 - ``earth_faa``: Add new dataset 'IGPP Earth Free Air Gravity Anomalies v31' [`Sandwell et al., 2019 <https://doi.org/10.1016/j.asr.2019.09.011>`_; `Pavlis et al., 2012 <https://doi.org/10.1029/2011JB008916>`_].
 - ``earth_vgg``: Add new dataset 'IGPP Earth Vertical Gravity Gradient Anomalies v31' [`Sandwell et al., 2019 <https://doi.org/10.1016/j.asr.2019.09.011>`_; `Pavlis et al., 2012 <https://doi.org/10.1029/2011JB008916>`_].
-- ``earth_synbath``: Add new dataset 'SYNBATH Earth Relief' [`Sandwell et al., 2022 <http://dx.doi.org/10.1002/essoar.10508279.1>`_].
+- ``earth_synbath``: Add new dataset 'SYNBATH Earth Relief' [`Sandwell et al., 2022 <https://doi.org/10.1002/essoar.10508279.1>`_].
 - ``earth_wdmam``: Add new dataset 'WDMAM Earth Magnetic Anomalies' [`Lesur et al., 2016 <https://doi.org/10.1186/s40623-016-0404-6>`_].
-- ``earth_relief``: Update dataset source from SRTM15+V2.1 to SRTM15+V2.3 [`Sandwell et al., 2022 <http://dx.doi.org/10.1002/essoar.10508279.1>`_].
+- ``earth_relief``: Update dataset source from SRTM15+V2.1 to SRTM15+V2.3 [`Sandwell et al., 2022 <https://doi.org/10.1002/essoar.10508279.1>`_].
 - ``earth_age``: Update dataset name from 'Earth Seafloor Crustal Age Models' to 'EarthByte Earth Seafloor Age'.
 - ``earth_mask``: Update dataset name from 'Earth Masks for ocean/land/lake/island/pond' to 'GSHHG Earth Mask'.
 - ``earth_relief``: Update dataset name from 'Earth Digital Elevation Models' to 'IGPP Global Earth Relief'.

--- a/docs/earth-age.rst
+++ b/docs/earth-age.rst
@@ -61,4 +61,4 @@ to the 2012 Geological Time Scale.
 Data References
 ~~~~~~~~~~~~~~~
 
-#. Seton et al., 2020: [http://dx.doi.org/10.1029/2020GC009214].
+#. Seton et al., 2020: [https://doi.org/10.1029/2020GC009214].

--- a/docs/earth-wdmam.rst
+++ b/docs/earth-wdmam.rst
@@ -58,7 +58,7 @@ Data References
 ~~~~~~~~~~~~~~~
 
 #. Choi, Y., Dyment, J., Lesur, V., Garcia Reyes, Catalan, M., Ishihara, T., Litvinova, T., Hamoudi, M.,
-   the WDMAM Task Force*, and the WDMAM Data Providers**, World Digital Magnetic Anomaly Map version 2.1, map available at http://www.wdmam.org/.
+   the WDMAM Task Force*, and the WDMAM Data Providers**, World Digital Magnetic Anomaly Map version 2.1, map available at https://www.wdmam.org/.
 
   \* The WDMAM Task Force: J. Dyment (chair), M. Catalan (co-chair), A. de Santis, M. Hamoudi, T. Ishihara, J. Korhonen, V. Lesur, T. Litvinova, J. Luis, B. Meyer, P. Milligan, M. Nakanishi, S. Okuma, M. Pilkington, M. Purucker, D. Ravat, E. Thébault. (alphabetical order)
 


### PR DESCRIPTION
Reference: https://www.crossref.org/display-guidelines/

> When displaying DOIs, it’s important to follow these display guidelines. Crossref DOIs should:
> 
> - always be displayed as a full URL link in the form https://doi.org/10.xxxx/xxxxx
> - not be preceded by doi: or DOI:
> - not use dx in the domain name part of DOI links
> - and we recommend HTTPS (rather than HTTP).

