### PR TITLE
Fix the formatting of earth daynight documentation

### DIFF
--- a/docs/earth-daynight.rst
+++ b/docs/earth-daynight.rst
@@ -28,9 +28,9 @@ Similarly for the nighttime view:
 
    @earth_night[_\ *rru*]
 
-The following codes for *rr*\ *u* are supported. The sizes refers to the earth_day version 
-(the earth_night ranges from 33% smaller for the highest resolution up to 44% bigger for 
-the lowest resolution)::
+The following codes for *rr*\ *u* are supported. The sizes refers to the earth_day version
+(the earth_night ranges from 33% smaller for the highest resolution up to 44% bigger for
+the lowest resolution):
 
 .. _tbl-earth_daynight:
 


### PR DESCRIPTION
Currently, it looks bad:

<img width="981" alt="image" src="https://github.com/GenericMappingTools/remote-datasets/assets/3974108/12e7dd79-e487-4960-88b1-ddb939b2572d">
