### PR TITLE
Remove "Global" from remote dataset names in the table captions

### DIFF
--- a/docs/earth-age.rst
+++ b/docs/earth-age.rst
@@ -25,7 +25,7 @@ for pixel-registered grids; gridline-registered grids increment dimensions by on
 
 .. _tbl-earth_age:
 
-.. table:: EarthByte Global Earth Seafloor Crustal Age. An asterisk denotes tiled datasets.
+.. table:: EarthByte Earth Seafloor Crustal Age. An asterisk denotes tiled datasets.
 
   ==== ================= === =======  ==================================================
   Code Dimensions        Reg Size     Description

--- a/docs/earth-daynight.rst
+++ b/docs/earth-daynight.rst
@@ -34,7 +34,7 @@ the lowest resolution):
 
 .. _tbl-earth_daynight:
 
-.. table:: NASA Global Earth Day/Night Images.
+.. table:: NASA Earth Day/Night Images.
 
   ==== ================= =======  ===========================================================
   Code Dimensions        Size     Description

--- a/docs/earth-faa.rst
+++ b/docs/earth-faa.rst
@@ -28,7 +28,7 @@ for pixel-registered grids; gridline-registered grids increment dimensions by on
 
 .. _tbl-earth_faa:
 
-.. table:: IGPP Global Earth Free-Air Anomaly. An asterisk denotes tiled datasets.
+.. table:: IGPP Earth Free-Air Anomaly. An asterisk denotes tiled datasets.
 
   ==== ================= === =======  =======================================
   Code Dimensions        Reg Size     Description

--- a/docs/earth-faaerror.rst
+++ b/docs/earth-faaerror.rst
@@ -27,7 +27,7 @@ for pixel-registered grids; gridline-registered grids increment dimensions by on
 
 .. _tbl-earth_faaerror:
 
-.. table:: IGPP Global Earth Free-Air Anomaly. An asterisk denotes tiled datasets.
+.. table:: IGPP Earth Free-Air Anomaly. An asterisk denotes tiled datasets.
 
   ==== ================= === =======  ========================================
   Code Dimensions        Reg Size     Description

--- a/docs/earth-gebco.rst
+++ b/docs/earth-gebco.rst
@@ -28,7 +28,7 @@ for pixel-registered grids; gridline-registered grids increment dimensions by on
 
 .. _tbl-earth_gebco:
 
-.. table:: GEBCO Global Earth Relief. An asterisk denotes tiled datasets.
+.. table:: GEBCO Earth Relief. An asterisk denotes tiled datasets.
 
   ==== ================= === =======  ================================================
   Code Dimensions        Reg Size     Description

--- a/docs/earth-geoid.rst
+++ b/docs/earth-geoid.rst
@@ -20,7 +20,7 @@ for pixel-registered grids; gridline-registered grids increment dimensions by on
 
 .. _tbl-earth_geoid:
 
-.. table:: EGM2008 Global Earth Geoid. An asterisk denotes tiled datasets.
+.. table:: EGM2008 Earth Geoid. An asterisk denotes tiled datasets.
 
   ==== ================= === =======  ==================================================
   Code Dimensions        Reg Size     Description

--- a/docs/earth-mag.rst
+++ b/docs/earth-mag.rst
@@ -28,7 +28,7 @@ refers to the ``earth_mag4km`` version (the oceanic files are ~60% smaller):
 
 .. _tbl-earth_mag:
 
-.. table:: EMAG2 Global Earth Magnetic Anomaly Model. An asterisk denotes tiled datasets.
+.. table:: EMAG2 Earth Magnetic Anomaly Model. An asterisk denotes tiled datasets.
 
   ==== ================= === =======  ==========================================
   Code Dimensions        Reg Size     Description

--- a/docs/earth-mask.rst
+++ b/docs/earth-mask.rst
@@ -29,7 +29,7 @@ for pixel-registered grids; gridline-registered grids increment dimensions by on
 
 .. _tbl-earth_masks:
 
-.. table:: GSHHG Global Earth Mask
+.. table:: GSHHG Earth Mask
 
   ==== ================= === =======  =====================================================
   Code Dimensions        Reg Size     Description

--- a/docs/earth-mdt.rst
+++ b/docs/earth-mdt.rst
@@ -23,7 +23,7 @@ for pixel-registered grids; gridline-registered grids increment dimensions by on
 
 .. _tbl-earth_mdt:
 
-.. table:: CNES Earth Mean Dynamic Topography. An asterisk denotes tiled datasets.
+.. table:: CNES Earth Mean Dynamic Topography.
 
   ==== ================= === =======  =======================================
   Code Dimensions        Reg Size     Description

--- a/docs/earth-mdt.rst
+++ b/docs/earth-mdt.rst
@@ -23,7 +23,7 @@ for pixel-registered grids; gridline-registered grids increment dimensions by on
 
 .. _tbl-earth_mdt:
 
-.. table:: CNES Global Earth Mean Dynamic Topography. An asterisk denotes tiled datasets.
+.. table:: CNES Earth Mean Dynamic Topography. An asterisk denotes tiled datasets.
 
   ==== ================= === =======  =======================================
   Code Dimensions        Reg Size     Description

--- a/docs/earth-mss.rst
+++ b/docs/earth-mss.rst
@@ -23,7 +23,7 @@ for pixel-registered grids; gridline-registered grids increment dimensions by on
 
 .. _tbl-earth_mss:
 
-.. table:: CNES Global Earth Mean Sea Surface. An asterisk denotes tiled datasets.
+.. table:: CNES Earth Mean Sea Surface. An asterisk denotes tiled datasets.
 
   ==== ================= === =======  =======================================
   Code Dimensions        Reg Size     Description

--- a/docs/earth-relief.rst
+++ b/docs/earth-relief.rst
@@ -30,7 +30,7 @@ for pixel-registered grids; gridline-registered grids increment dimensions by on
 
 .. _tbl-earth_relief:
 
-.. table:: IGPP Global Earth Relief. An asterisk denotes tiled datasets.
+.. table:: IGPP Earth Relief. An asterisk denotes tiled datasets.
 
   ==== ================= === =======  ==================================================
   Code Dimensions        Reg Size     Description

--- a/docs/earth-vgg.rst
+++ b/docs/earth-vgg.rst
@@ -27,7 +27,7 @@ for pixel-registered grids; gridline-registered grids increment dimensions by on
 
 .. _tbl-earth_vgg:
 
-.. table:: IGPP Global Earth Vertical Gravity Gradient. An asterisk denotes tiled datasets.
+.. table:: IGPP Earth Vertical Gravity Gradient. An asterisk denotes tiled datasets.
 
   ==== ================= === =======  ========================================
   Code Dimensions        Reg Size     Description


### PR DESCRIPTION
This PR aims to remove "Global" from the remote dataset names in the table captions to be consistent with the title (see PR https://github.com/GenericMappingTools/remote-datasets/pull/98 ).