### PR TITLE
Add text-align center for Gebco card

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -38,6 +38,7 @@ when GMT 6.5 is released.
         :link: earth-gebco
         :link-type: doc
         :img-bottom: /_static/GMT_earth_gebco_thumbnail.jpg
+        :text-align: center
 
     .. grid-item-card:: GSHHG Earth Mask
         :link: earth-mask

--- a/docs/pluto-relief.rst
+++ b/docs/pluto-relief.rst
@@ -1,4 +1,4 @@
-USGA Pluto Relief
+USGS Pluto Relief
 -----------------
 
 .. figure:: /_static/usgs.png


### PR DESCRIPTION
The title of "Gebco Earth relief" is align to the left while the rest is align to the center. 

See https://www.generic-mapping-tools.org/remote-datasets/index.html