### PR TITLE
update earth-dist to reflect that data are in kilometers, not meters

### DIFF
--- a/docs/earth-dist.rst
+++ b/docs/earth-dist.rst
@@ -51,7 +51,7 @@ We scale and reformat the original data to take up very little space so that dow
 from the servers are as fast as possible. For the distance grid this meant
 we chose 80 m as the smallest data unit, which is below the uncertainties in the
 model. Data are scaled and shifted to fit in a short integer grid that is highly compressed
-by netCDF lossless compression and chunking. The data are reported in meters.
+by netCDF lossless compression and chunking. The data are reported in kilometers.
 
 Data References
 ~~~~~~~~~~~~~~~


### PR DESCRIPTION
After running a simple

`gmt grdcut @earth_dist_01m_g -Rg -Gearth_dist_01m_g_test`

Followed by

`gmt grdinfo earth_dist_01m_g_test`

one sees that the min/max is roughly -2698 to 2513. This must be in kilometers. 

This is my first time contributing to any open source project. Apologies in advance if I was supposed to do this another way.