### PR TITLE
Add srtm-relief to toctree

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -168,6 +168,7 @@ Information about the GMT data server and mirrors can be found on the
    earth-ndefl
    earth-relief
    earth-vgg
+   srtm-relief
    earth-wdmam
    mars-relief
    mercury-relief

--- a/docs/srtm-relief.rst
+++ b/docs/srtm-relief.rst
@@ -1,5 +1,5 @@
 NASA SRTM Relief
------------------
+----------------
 
 .. figure:: /_static/nasa-logo-web-rgb.png
    :align: right


### PR DESCRIPTION
I forgot to include `srtm-relief` in the `toctree` when the dataset was added (#135). This PR fixes it.

I’m fairly confident this resolves the issue, but I couldn’t rebuild the HTML locally — I’d appreciate a quick review.